### PR TITLE
181780 Aging data clean-up of DYSAC all environments

### DIFF
--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -80,9 +80,6 @@
         "dysacContentCollectionName": {
             "value": "__dysacContentCollectionName__"
         },
-        "dysacAssessmentCollectionName": {
-            "value": "__dysacAssessmentCollectionName__"
-        },
         "sessionStateCollectionName": {
             "value": "__sessionStateCollectionName__"
         },

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -105,9 +105,6 @@
     "SubscriptionApiEndpointUrl": {
       "type": "string"
     },
-    "dysacAssessmentCollectionName": {
-      "type": "string"
-    },
     "dysacContentCollectionName": {
       "type": "string"
     },
@@ -278,39 +275,6 @@
           },
           "collectionName": {
             "value": "[parameters('sessionStateCollectionName')]"
-          },
-          "provisionRequestUnits": {
-            "value": false
-          },
-          "partitionKey": {
-            "value": "[variables('cosmosDbCollectionPartitionKey')]"
-          }
-        }
-      },
-      "dependsOn": [
-        "[variables('CosmosDbDatabaseName')]"
-      ]
-    },
-    {
-      "apiVersion": "2017-05-10",
-      "name": "[parameters('dysacAssessmentCollectionName')]",
-      "type": "Microsoft.Resources/deployments",
-      "resourceGroup": "[parameters('CosmosDbResourceGroup')]",
-      "properties": {
-        "mode": "Incremental",
-        "templateLink": {
-          "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'CosmosDb/cosmos-collection.json')]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "accountName": {
-            "value": "[parameters('cosmosDbName')]"
-          },
-          "databaseName": {
-            "value": "[variables('cosmosDbDatabaseName')]"
-          },
-          "collectionName": {
-            "value": "[parameters('dysacAssessmentCollectionName')]"
           },
           "provisionRequestUnits": {
             "value": false
@@ -544,26 +508,6 @@
               },
               {
                 "name": "Configuration__CosmosDbConnections__SessionState__PartitionKey",
-                "value": "[variables('cosmosDbCollectionPartitionKey')]"
-              },
-              {
-                "name": "Configuration__CosmosDbConnections__DysacAssessment__AccessKey",
-                "value": "[parameters('cosmosDbKey')]"
-              },
-              {
-                "name": "Configuration__CosmosDbConnections__DysacAssessment__EndpointUrl",
-                "value": "[variables('cosmosDbEndpoint')]"
-              },
-              {
-                "name": "Configuration__CosmosDbConnections__DysacAssessment__DatabaseId",
-                "value": "[variables('cosmosDbDatabaseName')]"
-              },
-              {
-                "name": "Configuration__CosmosDbConnections__DysacAssessment__CollectionId",
-                "value": "[parameters('dysacAssessmentCollectionName')]"
-              },
-              {
-                "name": "Configuration__CosmosDbConnections__DysacAssessment__PartitionKey",
                 "value": "[variables('cosmosDbCollectionPartitionKey')]"
               },
               {

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -80,9 +80,6 @@
     "dysacContentCollectionName": {
       "value": "dysacContentCollectionName"
     },
-    "dysacAssessmentCollectionName": {
-      "value": "dysacAssessmentCollectionName"
-    },
     "sessionStateCollectionName": {
       "value": "sessionStateCollectionName"
     },


### PR DESCRIPTION
This PR removes the IaC for configuring DYSAC'S assessment collection in the dfc-app-dysac database  from this repository. This code has now been adapted to bicep and moved over to the `dfe-ncs-infrastructure` repository on AzureDevOps. The AzDo work item this relates to is [181780 Aging data clean-up of DYSAC all environments](https://sfa-gov-uk.visualstudio.com/National%20Careers%20Service%20(NCS)/_boards/board/t/DevOps/Stories?workitem=181780)